### PR TITLE
Import cleanup

### DIFF
--- a/serenity-cucumber-archetype/src/main/resources/archetype-resources/src/main/java/pages/DictionaryPage.java
+++ b/serenity-cucumber-archetype/src/main/resources/archetype-resources/src/main/java/pages/DictionaryPage.java
@@ -6,12 +6,10 @@ package ${package}.pages;
 import ch.lambdaj.function.convert.Converter;
 import net.thucydides.core.annotations.DefaultUrl;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import net.thucydides.core.pages.WebElementFacade;
+import net.serenitybdd.core.pages.WebElementFacade;
 
-import net.thucydides.core.annotations.findby.FindBy;
+import net.serenitybdd.core.annotations.findby.FindBy;
 
 import net.thucydides.core.pages.PageObject;
 

--- a/serenity-cucumber-archetype/src/main/resources/archetype-resources/src/main/java/steps/EndUserSteps.java
+++ b/serenity-cucumber-archetype/src/main/resources/archetype-resources/src/main/java/steps/EndUserSteps.java
@@ -5,10 +5,8 @@ package ${package}.steps;
 
 import ${package}.pages.DictionaryPage;
 import net.thucydides.core.annotations.Step;
-import net.thucydides.core.pages.Pages;
 import net.thucydides.core.steps.ScenarioSteps;
 
-import static ch.lambdaj.Lambda.join;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;


### PR DESCRIPTION
Fixed issue #1 - Cucumber-archtype contains deprecated annotations (like old thucydides FindBy and WebElementFacade). Want to get rid of them by using the proper ones.
